### PR TITLE
Update README.md and add warnings on DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains 3 projects for demonstrating the capabilities and use c
 - [Learning Airflow](learning-airflow/README.md) A project for learning the basics of Airflow
 
 ## Purpose of This Repository
-These templates are designed to help new users learn and try Airflow quickly. As you move your workloads into business-critical applications or adopt advanced Airflow features, reach out at to [Astronomer's Airflow experts](https://www.astronomer.io/contact/) to get help deploying to production.
+These templates are designed to help new users learn and try Airflow quickly. As you move your workloads into business-critical applications or adopt advanced Airflow features, reach out to [Astronomer's Airflow experts](https://www.astronomer.io/contact/) to get help deploying to production.
 
 ## Run a Template Locally
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This repository contains 3 projects for demonstrating the capabilities and use c
 - [Generative AI](generative-ai/README.md) A project for learning how to use Airflow to train a generative AI model
 - [Learning Airflow](learning-airflow/README.md) A project for learning the basics of Airflow
 
+## Purpose of This Repository
+These templates are designed to help new users learn and try Airflow quickly. As you move your workloads into business-critical applications or adopt advanced Airflow features, reach out at to [Astronomer's Airflow experts](https://www.astronomer.io/contact/) to get help deploying to production.
+
 ## Run a Template Locally
 
 1. Navigate to your chosen project by selecting an option in the table of contents above

--- a/dbt-on-astro/README.md
+++ b/dbt-on-astro/README.md
@@ -8,19 +8,27 @@ This project showcases using dbt and Airflow together with [Cosmos](https://gith
 
 To learn more about data engineering with Apache Airflow, dbt, and Cosmos, make a few changes to this project! For example, try one of the following:
 
-1. Write a new DAG to 
-2. Take a look at the architecture of [Ask Astro](https://github.com/astronomer/ask-astro), Astronomer's reference architecture for LLM applications
+1. Use Postgres, MySQL, Snowflake, or another production-ready database instead of DuckDB
+2. Change the Cosmos DbtDag to Cosmos DbtTaskGroups! For extra help, check out the [Cosmos examples of DbtTaskGroups](https://github.com/astronomer/astronomer-cosmos/blob/main/dev/dags/basic_cosmos_task_group.py)
 
 # Project Contents
 
 Your Astro project contains the following files and folders:
 
-- dags: This folder contains the Python files for your Airflow DAGs. By default, this directory includes one example DAG:
-  - `example_vector_embeddings.py`: This DAG demonstrates how to compute vector embeddings of words using the SentenceTransformers library and
-    compare the embeddings of a word of interest to a list of words to find the semantically closest match.get-started-with-airflow).
+- dags: This folder contains the Python files for your Airflow DAGs. This directory includes one example DAG:
+  - `dbt_cosmos_dag.py`: This DAG sets up [Cosmos](https://github.com/astronomer/astronomer-cosmos), allowing files in the /dbt directory to transform into Airflow tasks and taskgroups.
+- dbt/jaffle_shop: This folder contains the dbt project [jaffle_shop](https://github.com/dbt-labs/jaffle_shop_duckdb), a fictional ecommerce store. Use this as a starting point to learn how dbt and Airflow work together!
 - Dockerfile: This file contains a versioned Astro Runtime Docker image that provides a differentiated Airflow experience. If you want to execute other commands or overrides at runtime, specify them here.
 - include: This folder contains any additional files that you want to include as part of your project. It is empty by default.
 - packages.txt: Install OS-level packages needed for your project by adding them to this file. It is empty by default.
 - requirements.txt: Install Python packages needed for your project by adding them to this file. It is empty by default.
 - plugins: Add custom or community plugins for your project to this file. It is empty by default.
 - airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.
+
+# Moving to Production
+
+### ❗Warning❗
+This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.  
+
+
+

--- a/dbt-on-astro/README.md
+++ b/dbt-on-astro/README.md
@@ -28,7 +28,7 @@ Your Astro project contains the following files and folders:
 # Deploying to Production
 
 ### ❗Warning❗
-This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.  
+This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ instead (consider DuckDB's hosted option MotherDuck or another database like Postgres, MySQL, or Snowflake).
 
 
 

--- a/dbt-on-astro/README.md
+++ b/dbt-on-astro/README.md
@@ -19,16 +19,14 @@ Your Astro project contains the following files and folders:
   - `dbt_cosmos_dag.py`: This DAG sets up [Cosmos](https://github.com/astronomer/astronomer-cosmos), allowing files in the /dbt directory to transform into Airflow tasks and taskgroups.
 - dbt/jaffle_shop: This folder contains the dbt project [jaffle_shop](https://github.com/dbt-labs/jaffle_shop_duckdb), a fictional ecommerce store. Use this as a starting point to learn how dbt and Airflow work together!
 - Dockerfile: This file contains a versioned Astro Runtime Docker image that provides a differentiated Airflow experience. If you want to execute other commands or overrides at runtime, specify them here.
-- include: This folder contains any additional files that you want to include as part of your project. It is empty by default.
+- include: This folder contains any additional files that you want to include as part of your project. In this example, constants.py includes configuration for your Cosmos project.
 - packages.txt: Install OS-level packages needed for your project by adding them to this file. It is empty by default.
-- requirements.txt: Install Python packages needed for your project by adding them to this file. It is empty by default.
+- requirements.txt: Install Python packages needed for your project by adding them to this file. In this project, we pin the Cosmos version.
 - plugins: Add custom or community plugins for your project to this file. It is empty by default.
 - airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.
 
 # Deploying to Production
 
 ### ❗Warning❗
+
 This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ instead (consider DuckDB's hosted option MotherDuck or another database like Postgres, MySQL, or Snowflake).
-
-
-

--- a/dbt-on-astro/README.md
+++ b/dbt-on-astro/README.md
@@ -25,7 +25,7 @@ Your Astro project contains the following files and folders:
 - plugins: Add custom or community plugins for your project to this file. It is empty by default.
 - airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.
 
-# Moving to Production
+# Deploying to Production
 
 ### ❗Warning❗
 This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.  

--- a/dbt-on-astro/README.md
+++ b/dbt-on-astro/README.md
@@ -15,7 +15,7 @@ To learn more about data engineering with Apache Airflow, dbt, and Cosmos, make 
 
 Your Astro project contains the following files and folders:
 
-- dags: This folder contains the Python files for your Airflow DAGs. This directory includes one example DAG:
+- dags: This folder contains the Python files for your Airflow DAGs. This project includes one example DAG:
   - `dbt_cosmos_dag.py`: This DAG sets up [Cosmos](https://github.com/astronomer/astronomer-cosmos), allowing files in the /dbt directory to transform into Airflow tasks and taskgroups.
 - dbt/jaffle_shop: This folder contains the dbt project [jaffle_shop](https://github.com/dbt-labs/jaffle_shop_duckdb), a fictional ecommerce store. Use this as a starting point to learn how dbt and Airflow work together!
 - Dockerfile: This file contains a versioned Astro Runtime Docker image that provides a differentiated Airflow experience. If you want to execute other commands or overrides at runtime, specify them here.

--- a/dbt-on-astro/README.md
+++ b/dbt-on-astro/README.md
@@ -1,23 +1,26 @@
-# cosmos-demo
+# Project Overview
 
-This repo contains a dbt project and a set of Airflow DAGs showing how to run dbt in Airflow using [Cosmos](https://github.com/astronomer/astronomer-cosmos).
+Apache Airflow is one of the most widely-used engines for orchestrating Extract, Transform, and Load (ETL) jobs, especially for transformations using [dbt](https://www.getdbt.com). dbt is a framework to create reliable transformations to produce high-quality data for businesses, usually in analytical databases like Snowflake and BigQuery.
 
-To run this, you'll need:
+This project showcases using dbt and Airflow together with [Cosmos](https://github.com/astronomer/astronomer-cosmos), allowing users to deploy dbt in production with Airflow best-practices.
 
-- [The Astro CLI installed](https://docs.astronomer.io/astro/cli/overview)
-- Docker
+# Learning Paths
 
-## Setup
+To learn more about data engineering with Apache Airflow, dbt, and Cosmos, make a few changes to this project! For example, try one of the following:
 
-1. Clone this repo
-2. Run `astro dev start` to start the Airflow instance
+1. Write a new DAG to 
+2. Take a look at the architecture of [Ask Astro](https://github.com/astronomer/ask-astro), Astronomer's reference architecture for LLM applications
 
-## The DAGs
+# Project Contents
 
-The DAGs in this repo are meant to illustrate how to run dbt in Airflow using Cosmos. They use dbt's jaffle_shop example project.
+Your Astro project contains the following files and folders:
 
-The DAGs fall into three categories:
-
-- Basic: these are the simplest examples of Cosmos
-- Profiles: these show how to customize your dbt profiles using Cosmos
-- Filtering: these show how to use Cosmos to filter which models are run
+- dags: This folder contains the Python files for your Airflow DAGs. By default, this directory includes one example DAG:
+  - `example_vector_embeddings.py`: This DAG demonstrates how to compute vector embeddings of words using the SentenceTransformers library and
+    compare the embeddings of a word of interest to a list of words to find the semantically closest match.get-started-with-airflow).
+- Dockerfile: This file contains a versioned Astro Runtime Docker image that provides a differentiated Airflow experience. If you want to execute other commands or overrides at runtime, specify them here.
+- include: This folder contains any additional files that you want to include as part of your project. It is empty by default.
+- packages.txt: Install OS-level packages needed for your project by adding them to this file. It is empty by default.
+- requirements.txt: Install Python packages needed for your project by adding them to this file. It is empty by default.
+- plugins: Add custom or community plugins for your project to this file. It is empty by default.
+- airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.

--- a/dbt-on-astro/dags/dbt_cosmos_dag.py
+++ b/dbt-on-astro/dags/dbt_cosmos_dag.py
@@ -20,8 +20,7 @@ dbt_cosmos_dag = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="dbt_cosmos_dag",
-    # Warning - DuckDB is not a persistent database between workers. To move this workflow in production,
-    # use a persistent DB and remove the max_active_runs and concurrency parameters below
+    # Warning - in-memory DuckDB is not a persistent database between workers. To move this workflow in production, use a cloud-based database and based on concurrency capabilities adjust the two parameters below.
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )

--- a/dbt-on-astro/dags/dbt_cosmos_dag.py
+++ b/dbt-on-astro/dags/dbt_cosmos_dag.py
@@ -20,8 +20,8 @@ dbt_cosmos_dag = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="dbt_cosmos_dag",
-    # Duckdb adapter-specific parameters
-    # Since duckdb is an in-memory database, we can only run one dbt command at a time
-    max_active_runs=1,
-    concurrency=1,
+    # Warning - DuckDB is not a persistent database between workers. To move this workflow in production,
+    # use a persistent DB and remove the max_active_runs and concurrency parameters below
+    max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
+    concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )

--- a/dbt-on-astro/dags/dbt_cosmos_dag.py
+++ b/dbt-on-astro/dags/dbt_cosmos_dag.py
@@ -20,7 +20,8 @@ dbt_cosmos_dag = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="dbt_cosmos_dag",
-    # Warning - in-memory DuckDB is not a persistent database between workers. To move this workflow in production, use a cloud-based database and based on concurrency capabilities adjust the two parameters below.
+    # Warning - in-memory DuckDB is not a persistent database between workers. To move this workflow in production, use a 
+    # cloud-based database and based on concurrency capabilities adjust the two parameters below.
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )

--- a/etl/README.md
+++ b/etl/README.md
@@ -26,4 +26,4 @@ Your Astro project contains the following files and folders:
 # Deploying to Production
 
 ### ❗Warning❗
-This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.  
+This template used DuckDB, an in-memory database, for running ETL jobs. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.  

--- a/etl/README.md
+++ b/etl/README.md
@@ -22,3 +22,8 @@ Your Astro project contains the following files and folders:
 - requirements.txt: Install Python packages needed for your project by adding them to this file. It is empty by default.
 - plugins: Add custom or community plugins for your project to this file. It is empty by default.
 - airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.
+
+# Deploying to Production
+
+### ❗Warning❗
+This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.  

--- a/etl/README.md
+++ b/etl/README.md
@@ -26,4 +26,5 @@ Your Astro project contains the following files and folders:
 # Deploying to Production
 
 ### ❗Warning❗
-This template used DuckDB, an in-memory database, for running ETL jobs. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.  
+
+This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ instead (consider DuckDB's hosted option MotherDuck or another database like Postgres, MySQL, or Snowflake).

--- a/etl/dags/example_etl_galaxies.py
+++ b/etl/dags/example_etl_galaxies.py
@@ -63,7 +63,8 @@ _NUM_GALAXIES_TOTAL = os.getenv("NUM_GALAXIES_TOTAL", 20)
             description="Set how close galaxies need ot be to the milkyway in order to be loaded to DuckDB.",
         )
     },
-    # Warning - DuckDB is not a persistent database between workers. To move this workflow in production,
+    # Warning - In production, we recommend to use a cloud-based DB over local DuckDB. 
+    # Depending on the concurrency capabilities of your database, adjust the two parameters below.
     # use a persistent DB and remove the max_active_runs and concurrency parameters below
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls

--- a/etl/dags/example_etl_galaxies.py
+++ b/etl/dags/example_etl_galaxies.py
@@ -63,6 +63,10 @@ _NUM_GALAXIES_TOTAL = os.getenv("NUM_GALAXIES_TOTAL", 20)
             description="Set how close galaxies need ot be to the milkyway in order to be loaded to DuckDB.",
         )
     },
+    # Warning - DuckDB is not a persistent database between workers. To move this workflow in production,
+    # use a persistent DB and remove the max_active_runs and concurrency parameters below
+    max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
+    concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )
 def example_etl_galaxies():  # by default the dag_id is the name of the decorated function
 

--- a/etl/dags/example_etl_galaxies.py
+++ b/etl/dags/example_etl_galaxies.py
@@ -63,9 +63,8 @@ _NUM_GALAXIES_TOTAL = os.getenv("NUM_GALAXIES_TOTAL", 20)
             description="Set how close galaxies need ot be to the milkyway in order to be loaded to DuckDB.",
         )
     },
-    # Warning - In production, we recommend to use a cloud-based DB over local DuckDB. 
-    # Depending on the concurrency capabilities of your database, adjust the two parameters below.
-    # use a persistent DB and remove the max_active_runs and concurrency parameters below
+    # Warning - in-memory DuckDB is not a persistent database between workers. To move this workflow in production, use a 
+    # cloud-based database and based on concurrency capabilities adjust the two parameters below.
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )

--- a/generative-ai/README.md
+++ b/generative-ai/README.md
@@ -26,4 +26,5 @@ Your Astro project contains the following files and folders:
 # Deploying to Production
 
 ### ❗Warning❗
-This template used local DuckDB for storing words and running semantic search. While this is great to learn Airflow, for production applications, we recommend to use [cloud-based DuckDB](https://motherduck.com/) or switch to a different database like Postgres, MySQL, Snowflake, or others instead. 
+
+This template used DuckDB, an in-memory database, for running dbt transformations. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ instead (consider DuckDB's hosted option MotherDuck or another database like Postgres, MySQL, or Snowflake).

--- a/generative-ai/README.md
+++ b/generative-ai/README.md
@@ -22,3 +22,8 @@ Your Astro project contains the following files and folders:
 - requirements.txt: Install Python packages needed for your project by adding them to this file. It is empty by default.
 - plugins: Add custom or community plugins for your project to this file. It is empty by default.
 - airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.
+
+# Moving to Production
+
+### ❗Warning❗
+This template used DuckDB, an in-memory database, for running semantic search. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.

--- a/generative-ai/README.md
+++ b/generative-ai/README.md
@@ -26,4 +26,4 @@ Your Astro project contains the following files and folders:
 # Deploying to Production
 
 ### ❗Warning❗
-This template used DuckDB, an in-memory database, for running semantic search. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.
+This template used local DuckDB for storing words and running semantic search. While this is great to learn Airflow, for production applications, we recommend to use [cloud-based DuckDB](https://motherduck.com/) or switch to a different database like Postgres, MySQL, Snowflake, or others instead. 

--- a/generative-ai/README.md
+++ b/generative-ai/README.md
@@ -23,7 +23,7 @@ Your Astro project contains the following files and folders:
 - plugins: Add custom or community plugins for your project to this file. It is empty by default.
 - airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.
 
-# Moving to Production
+# Deploying to Production
 
 ### ❗Warning❗
 This template used DuckDB, an in-memory database, for running semantic search. While this is great to learn Airflow, your data is not guaranteed to persist between executions! For production applications, use a _persistent database_ like Postgres, MySQL, Snowflake, or others instead.

--- a/generative-ai/dags/example_vector_embeddings.py
+++ b/generative-ai/dags/example_vector_embeddings.py
@@ -47,7 +47,6 @@ _LIST_OF_WORDS_DEFAULT = ["sun", "rocket", "planet", "light", "happiness"]
     schedule="@daily",  # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
     catchup=False,  # see: https://www.astronomer.io/docs/learn/rerunning-dags#catchup
     max_consecutive_failed_dag_runs=5,  # auto-pauses the DAG after 5 consecutive failed runs, experimental
-    max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     doc_md=__doc__,  # add DAG Docs in the UI, see https://www.astronomer.io/docs/learn/custom-airflow-ui-docs-tutorial
     default_args={
         "owner": "Astro",  # owner of this DAG in the Airflow UI
@@ -69,6 +68,10 @@ _LIST_OF_WORDS_DEFAULT = ["sun", "rocket", "planet", "light", "happiness"]
             title="A list of words to compare to the word of interest.",
         ),
     },
+    # Warning - DuckDB is not a persistent database between workers. To move this workflow in production,
+    # use Postgres, MySQL, Snowflake, or another persistent DB
+    max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
+    concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )
 def example_vector_embeddings():  # by default the dag_id is the name of the decorated function
 

--- a/generative-ai/dags/example_vector_embeddings.py
+++ b/generative-ai/dags/example_vector_embeddings.py
@@ -68,8 +68,8 @@ _LIST_OF_WORDS_DEFAULT = ["sun", "rocket", "planet", "light", "happiness"]
             title="A list of words to compare to the word of interest.",
         ),
     },
-    # Warning - In production, we recommend to use a cloud-based DB over local DuckDB. 
-    # Depending on the concurrency capabilities of your database, adjust the two parameters below.
+    # Warning - in-memory DuckDB is not a persistent database between workers. To move this workflow in production, use a 
+    # cloud-based database and based on concurrency capabilities adjust the two parameters below.
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )

--- a/generative-ai/dags/example_vector_embeddings.py
+++ b/generative-ai/dags/example_vector_embeddings.py
@@ -68,8 +68,8 @@ _LIST_OF_WORDS_DEFAULT = ["sun", "rocket", "planet", "light", "happiness"]
             title="A list of words to compare to the word of interest.",
         ),
     },
-    # Warning - DuckDB is not a persistent database between workers. To move this workflow in production,
-    # use a persistent DB and remove the max_active_runs and concurrency parameters below
+    # Warning - In production, we recommend to use a cloud-based DB over local DuckDB. 
+    # Depending on the concurrency capabilities of your database, adjust the two parameters below.
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )

--- a/generative-ai/dags/example_vector_embeddings.py
+++ b/generative-ai/dags/example_vector_embeddings.py
@@ -69,7 +69,7 @@ _LIST_OF_WORDS_DEFAULT = ["sun", "rocket", "planet", "light", "happiness"]
         ),
     },
     # Warning - DuckDB is not a persistent database between workers. To move this workflow in production,
-    # use Postgres, MySQL, Snowflake, or another persistent DB
+    # use a persistent DB and remove the max_active_runs and concurrency parameters below
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
     concurrency=1, # only allow a single task execution at a time, prevents parallel DuckDB calls
 )


### PR DESCRIPTION
This PR updates the language in the README of dbt-on-Astro, in preparation for production release later today. 

In addition, we include a new warning to any of the templates using DuckDB to instead use a persistent RDBMS when running in production. 