### PR TITLE
Resolves Airflow Parsing Error

### DIFF
--- a/dbt-on-astro/requirements.txt
+++ b/dbt-on-astro/requirements.txt
@@ -1,1 +1,1 @@
-astronomer-cosmos==1.5.1
+astronomer-cosmos==1.6.0


### PR DESCRIPTION
The Runtime version for dbt-on-astro was recently updated to 12.0.0, however the cosmos version was left pinned at 1.5.1. These versions are unfortunately not compatible, and will throw an error in Airflow.

![image](https://github.com/user-attachments/assets/0f2ad276-d711-42c4-a9be-2b2b1f5d4094)

I updated cosmos to 1.6.0 to resolve this.