### PR TITLE
Add vss install to every task using vss

### DIFF
--- a/generative-ai/dags/example_vector_embeddings.py
+++ b/generative-ai/dags/example_vector_embeddings.py
@@ -171,6 +171,7 @@ def example_vector_embeddings():  # by default the dag_id is the name of the dec
         """
 
         cursor = duckdb.connect(duckdb_instance_name)
+        cursor.execute("INSTALL vss;")
         cursor.execute("LOAD vss;")
 
         for i in list_of_words_and_embeddings:
@@ -218,6 +219,7 @@ def example_vector_embeddings():  # by default the dag_id is the name of the dec
         """
 
         cursor = duckdb.connect(duckdb_instance_name)
+        cursor.execute("INSTALL vss;")
         cursor.execute("LOAD vss;")
 
         word = list(word_of_interest_embedding.keys())[0]


### PR DESCRIPTION
In the unlikely event of the tasks ending up on different workers, the latter ones will fail with 

```
  File "/usr/local/airflow/dags/example_vector_embeddings.py", line 174, in insert_words_into_db
    cursor.execute("LOAD vss;")
duckdb.duckdb.IOException: IO Error: Extension "/home/astro/.duckdb/extensions/v0.10.3/linux_amd64_gcc4/vss.duckdb_extension" not found.
```

installing in every task prevents that.